### PR TITLE
Fixing message URL embedding for iOS 11

### DIFF
--- a/Support/bin/add
+++ b/Support/bin/add
@@ -14,7 +14,7 @@ begin
   tmpfile.puts(ENV['MM_SUBJECT'])
 
   # The rest is the note
-  tmpfile.puts("Email: message://%3c" + CGI::escape(ENV['MM_MESSAGE_ID']) + "%3e")
+  tmpfile.puts("Email: <message:%3c" + ENV['MM_MESSAGE_ID'] + "%3e>")
 
   canonical = $stdin.read
   if !canonical.empty?


### PR DESCRIPTION
So... I finally found a combination that seems to work well across iOS 11 & macOS High Sierra. Feel free to reject if you have any issues with it, but it's worked well here. 😄